### PR TITLE
Fix NameError when reading Notion records

### DIFF
--- a/gastos/notion_api.py
+++ b/gastos/notion_api.py
@@ -56,7 +56,7 @@ def read_notion_records(timeout: int = 15) -> Optional[List[Dict]]:
         }
         properties_data.append(filtered_properties)
 
-    return records
+    return properties_data
 
 
 def export_notion_to_csv(csv_path: str) -> bool:


### PR DESCRIPTION
## Summary
- return the collected properties data from `read_notion_records`
- avoid raising a NameError when the Notion API data is processed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e63c2ccfbc83288e2f3c0eeb2ff373